### PR TITLE
Fetch from main

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Update to latest main
+        run: |
+          echo "Fetching latest changes..."
+          git fetch origin main
+          echo "Resetting to origin/main..."
+          git reset --hard origin/main
+
       - name: Log in to Azure Container Registry
         run: echo "${{ secrets.ACR_PASSWORD }}" | docker login fastapiregistry001.azurecr.io -u "${{ secrets.ACR_USERNAME }}" --password-stdin
 


### PR DESCRIPTION
This pull request introduces a new step in our GitHub Actions workflow to ensure that the build process always uses the most recent code from the main branch. By fetching and resetting to the latest main branch, we can prevent potential discrepancies and ensure consistency in our deployments.